### PR TITLE
style: BLOG-76 특정 카테고리에서 스타일 쪼그라드는 버그

### DIFF
--- a/src/app/_components/Cards/Card/index.module.scss
+++ b/src/app/_components/Cards/Card/index.module.scss
@@ -44,9 +44,6 @@
     &:hover {
       .card_content-description {
         & > p {
-          position: absolute;
-          top: 0;
-          left: 0;
           display: flex;
           flex-wrap: wrap;
           min-height: 62px;


### PR DESCRIPTION
## asis

<img width="356" alt="스크린샷 2024-11-30 오후 6 46 49" src="https://github.com/user-attachments/assets/42574c72-0783-432c-9f20-4e2c3b73dc22">


## tobe

<img width="983" alt="스크린샷 2024-11-30 오후 6 47 05" src="https://github.com/user-attachments/assets/8fe0c9d1-2ac1-4f54-8af0-581b2725e67c">
