### PR TITLE
perf: React.cache() 및 Promise.all 적용으로 성능 최적화

### DIFF
--- a/src/app/_components/Sidebar/index.tsx
+++ b/src/app/_components/Sidebar/index.tsx
@@ -16,14 +16,14 @@ import styles from "./index.module.scss";
 import { SidebarBtn } from "@/app/_components/Sidebar/SidebarBtn";
 import { useSidebarStore } from "@/app/_components/Sidebar/index.store";
 import { Menu } from "react-feather";
-import { PostType } from "@/types";
+import { PostWithoutMarkdownType } from "@/types";
 import { getPublishedSubCategories } from "@/app/_components/SidebarWrapper/utils";
 export interface SidebarProps {
   categories: {
     category: CategoryType;
     subcategories: SubCategoryType[];
   }[];
-  posts: PostType[];
+  posts: PostWithoutMarkdownType[];
 }
 const Sidebar = ({ categories, posts }: SidebarProps) => {
   const [isSidebarOn, setIsSidebarOn] = useSidebarStore((state) => [

--- a/src/app/_components/SidebarWrapper/index.tsx
+++ b/src/app/_components/SidebarWrapper/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PostType } from "@/types";
+import { PostWithoutMarkdownType } from "@/types";
 import { getCategories } from "@/app/api/dato/getCategories";
 
 import { formatSidebarData } from "@/app/_components/SidebarWrapper/utils";
@@ -9,8 +9,10 @@ import Sidebar from "@/app/_components/Sidebar";
 export const SidebarWrapper = async () => {
   // Promise.all로 병렬 실행하여 waterfall 제거
   const [postsResult, categoriesResult] = await Promise.all([
-    getPosts<{ allArticles: PostType[] }>(),
-    getCategories<{ allArticles: Pick<PostType, "category" | "_createdAt">[] }>(),
+    getPosts<{ allArticles: PostWithoutMarkdownType[] }>(),
+    getCategories<{
+      allArticles: Pick<PostWithoutMarkdownType, "category" | "_createdAt">[];
+    }>(),
   ]);
 
   const { allArticles: articles } = postsResult;

--- a/src/app/_components/SidebarWrapper/index.tsx
+++ b/src/app/_components/SidebarWrapper/index.tsx
@@ -7,13 +7,14 @@ import { getPosts } from "@/app/api/dato/getPosts";
 import Sidebar from "@/app/_components/Sidebar";
 
 export const SidebarWrapper = async () => {
-  const { allArticles: articles } = await getPosts<{
-    allArticles: PostType[];
-  }>();
+  // Promise.all로 병렬 실행하여 waterfall 제거
+  const [postsResult, categoriesResult] = await Promise.all([
+    getPosts<{ allArticles: PostType[] }>(),
+    getCategories<{ allArticles: Pick<PostType, "category" | "_createdAt">[] }>(),
+  ]);
 
-  const { allArticles: _subCategories } = await getCategories<{
-    allArticles: Pick<PostType, "category" | "_createdAt">[];
-  }>();
+  const { allArticles: articles } = postsResult;
+  const { allArticles: _subCategories } = categoriesResult;
 
   const subCategories = _subCategories.map(
     ({ category: _category, _createdAt }) => ({

--- a/src/app/_components/SidebarWrapper/utils/sidebar.tsx
+++ b/src/app/_components/SidebarWrapper/utils/sidebar.tsx
@@ -1,4 +1,4 @@
-import { PostType } from "@/types";
+import { PostWithoutMarkdownType } from "@/types";
 import { devideCategoryObject } from "@/utils/getCategoryLink";
 import { CategoryType, LinkType, SubCategoryType } from "junyeol-components";
 import Link from "next/link";
@@ -50,7 +50,7 @@ export const getPublishedSubCategories = ({
   posts,
   categories,
 }: {
-  posts: PostType[];
+  posts: PostWithoutMarkdownType[];
   categories: {
     category: CategoryType;
     subcategories: SubCategoryType[];

--- a/src/app/api/dato/getPostById.ts
+++ b/src/app/api/dato/getPostById.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { performRequest } from "@/libs/dato";
 
 import { REVALIDATE_TIME } from "@/utils/constant";
@@ -21,7 +22,7 @@ export const GET_POST_BY_ID = `
   }
 `;
 
-export const getPostById = async <T>(
+const _getPostById = async <T>(
   {
     postId,
   }: {
@@ -51,3 +52,6 @@ export const getPostById = async <T>(
     throw new Error("An unknown error occurred.");
   }
 };
+
+// React.cache()로 같은 렌더링 요청 내 중복 호출 방지
+export const getPostById = cache(_getPostById);

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { cache } from "react";
 import { getPostById } from "@/app/api/dato/getPostById";
 import { getPosts } from "@/app/api/dato/getPosts";
 import { HeadingIndexNav } from "@/app/_components/HeadingIndexNav";
@@ -10,11 +9,6 @@ import styles from "./index.module.scss";
 interface PostPageParams {
   params: { id: string };
 }
-
-// React.cache()로 같은 요청 내 중복 호출 방지
-const getCachedPostById = cache(async (postId: string) => {
-  return getPostById<Pick<PostType, "markdown" | "metaField">>({ postId });
-});
 
 export async function generateStaticParams() {
   const { allArticles: articles } = await getPosts<{
@@ -34,7 +28,9 @@ export async function generateStaticParams() {
 export default async function PostPageFilteredById({ params }: PostPageParams) {
   const {
     article: { markdown },
-  } = await getCachedPostById(params.id);
+  } = await getPostById<Pick<PostType, "markdown" | "metaField">>({
+    postId: params.id,
+  });
 
   return (
     <div className={`${styles.post_wrapper}`}>
@@ -47,7 +43,9 @@ export default async function PostPageFilteredById({ params }: PostPageParams) {
 export async function generateMetadata({
   params,
 }: PostPageParams): Promise<Metadata> {
-  const data = await getCachedPostById(params.id);
+  const data = await getPostById<Pick<PostType, "markdown" | "metaField">>({
+    postId: params.id,
+  });
 
   const { metaField } = data.article;
 

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { getPostById } from "@/app/api/dato/getPostById";
 import { getPosts } from "@/app/api/dato/getPosts";
 import { HeadingIndexNav } from "@/app/_components/HeadingIndexNav";
@@ -9,6 +10,11 @@ import styles from "./index.module.scss";
 interface PostPageParams {
   params: { id: string };
 }
+
+// React.cache()로 같은 요청 내 중복 호출 방지
+const getCachedPostById = cache(async (postId: string) => {
+  return getPostById<Pick<PostType, "markdown" | "metaField">>({ postId });
+});
 
 export async function generateStaticParams() {
   const { allArticles: articles } = await getPosts<{
@@ -28,9 +34,7 @@ export async function generateStaticParams() {
 export default async function PostPageFilteredById({ params }: PostPageParams) {
   const {
     article: { markdown },
-  } = await getPostById<Pick<PostType, "markdown" | "metaField">>({
-    postId: params.id,
-  });
+  } = await getCachedPostById(params.id);
 
   return (
     <div className={`${styles.post_wrapper}`}>
@@ -43,9 +47,7 @@ export default async function PostPageFilteredById({ params }: PostPageParams) {
 export async function generateMetadata({
   params,
 }: PostPageParams): Promise<Metadata> {
-  const data = await getPostById<Pick<PostType, "metaField">>({
-    postId: String(params.id),
-  });
+  const data = await getCachedPostById(params.id);
 
   const { metaField } = data.article;
 

--- a/src/app/posts/[category]/page.tsx
+++ b/src/app/posts/[category]/page.tsx
@@ -7,7 +7,6 @@ import React from "react";
 import styles from "../page.module.scss";
 import { getCategories } from "@/app/api/dato/getCategories";
 import { getCategoriesAndSubCategories } from "@/app/sitemap";
-import { paginatePosts } from "@/libs/paginate";
 
 interface PostsPageFilteredByCategory extends SearchParamsType {
   params: {
@@ -34,7 +33,6 @@ export async function generateStaticParams() {
 
 export default async function PostsPageFilteredByCategory({
   params,
-  searchParams,
 }: PostsPageFilteredByCategory) {
   const { category } = params;
   // const currentPage = Number(searchParams.currentPage);
@@ -44,7 +42,7 @@ export default async function PostsPageFilteredByCategory({
   }>();
 
   const filteredArticles = articles.filter(
-    (article) => !!article.category.category[category],
+    (article) => !!article.category.category[category]
   );
   // ** pagination으로 바꿀때 주석 해제 **//
 


### PR DESCRIPTION
## Summary

- **post/[id]/page.tsx**: React.cache()로 getPostById 중복 호출 제거 (API 호출 2번 → 1번)
- **SidebarWrapper**: Promise.all로 getPosts/getCategories 병렬 실행 (waterfall 제거)
- **posts/[category]/page.tsx**: 미사용 searchParams 파라미터 제거

## 성능 개선 효과

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| Post 페이지 API 호출 | 2번 | 1번 |
| Sidebar 데이터 페칭 | 순차 실행 | 병렬 실행 |

## Test plan

- [x] TypeScript 타입 체크 통과
- [x] 프로덕션 빌드 성공 (33/33 페이지 생성)
- [x] console.log로 API 호출 횟수 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)