### PR TITLE
feat: TOC 고도화 - H2~H5 지원 및 현재 섹션 하이라이트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,16 +238,16 @@ const observer = new IntersectionObserver(
     });
   },
   {
-    rootMargin: "-$HEADER_HEIGHT 0px -80% 0px", // 고정 헤더 오프셋
+    rootMargin: "-86px 0px -80% 0px", // 고정 헤더(86px) 오프셋
     threshold: 0,
   }
 );
 ```
 
 ### 스크롤 오프셋 처리
-- **CSS 방식**: `scroll-margin-top: $HEADER_HEIGHT` (Heading 앵커에 적용)
-- **JS 방식**: `scrollTo(top: elementPosition + scrollY - HEADER_HEIGHT)`
-- **Observer 방식**: `rootMargin`으로 뷰포트 경계 조정
+- **CSS 방식**: `scroll-margin-top: $HEADER_HEIGHT` (SCSS 변수, Heading 앵커에 적용)
+- **JS 방식**: `scrollTo(top: elementPosition + scrollY - 86)`
+- **Observer 방식**: `rootMargin: "-86px 0px -80% 0px"`으로 뷰포트 경계 조정
 
 ### 컴포넌트 구조
 ```

--- a/src/app/_components/HeadingIndexNav/TOCList.module.scss
+++ b/src/app/_components/HeadingIndexNav/TOCList.module.scss
@@ -1,0 +1,69 @@
+@use "src/styles/libs" as *;
+
+.tocContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.tocList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tocItem {
+  font-size: 14px;
+  line-height: 1.4;
+  transition: all 0.2s ease;
+
+  a {
+    display: block;
+    color: $BLUISH-GRAY-500;
+    text-decoration: none;
+    padding: 4px 0;
+    padding-left: 12px;
+    border-left: 2px solid transparent;
+    transition: all 0.2s ease;
+
+    &:hover {
+      color: $BLUISH-GRAY-800;
+    }
+  }
+
+  &.active {
+    a {
+      color: $BLUE-600;
+      border-left-color: $BLUE-600;
+      font-weight: 500;
+    }
+  }
+}
+
+.level2 {
+  a {
+    padding-left: 12px;
+  }
+}
+
+.level3 {
+  a {
+    padding-left: 24px;
+  }
+}
+
+.level4 {
+  a {
+    padding-left: 36px;
+    font-size: 13px;
+  }
+}
+
+.level5 {
+  a {
+    padding-left: 48px;
+    font-size: 13px;
+  }
+}

--- a/src/app/_components/HeadingIndexNav/TOCList.tsx
+++ b/src/app/_components/HeadingIndexNav/TOCList.tsx
@@ -17,15 +17,15 @@ export const TOCList = ({ headings }: TOCListProps) => {
   return (
     <div className={styles.tocContainer}>
       <ul className={styles.tocList}>
-        {headings.map((heading, i) => (
+        {headings.map(({ id, level, text }) => (
           <li
-            key={i}
-            className={`${styles.tocItem} ${styles[`level${heading.level}`]} ${
-              activeId === heading.id ? styles.active : ""
+            key={id}
+            className={`${styles.tocItem} ${styles[`level${level}`]} ${
+              activeId === id ? styles.active : ""
             }`}
           >
-            <Link href={`#${heading.id}`} scroll>
-              {heading.text}
+            <Link href={`#${id}`} scroll>
+              {text}
             </Link>
           </li>
         ))}

--- a/src/app/_components/HeadingIndexNav/TOCList.tsx
+++ b/src/app/_components/HeadingIndexNav/TOCList.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React from "react";
+import { HeadingType } from "@/types";
+import { useTOCHighlight } from "./useTOCHighlight";
+import styles from "./TOCList.module.scss";
+import Link from "next/link";
+
+interface TOCListProps {
+  headings: HeadingType[];
+}
+
+export const TOCList = ({ headings }: TOCListProps) => {
+  const activeId = useTOCHighlight(headings);
+
+  if (headings.length === 0) return null;
+
+  return (
+    <div className={styles.tocContainer}>
+      <ul className={styles.tocList}>
+        {headings.map((heading, i) => (
+          <li
+            key={i}
+            className={`${styles.tocItem} ${styles[`level${heading.level}`]} ${
+              activeId === heading.id ? styles.active : ""
+            }`}
+          >
+            <Link href={`#${heading.id}`} scroll>
+              {heading.text}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/app/_components/HeadingIndexNav/index.module.scss
+++ b/src/app/_components/HeadingIndexNav/index.module.scss
@@ -1,26 +1,14 @@
 @use "src/styles/libs" as *;
 
-.heading_index_nav {
+.headingIndexNav {
   display: none;
+
   @include desktop_screen {
     position: sticky;
     top: 100px;
-    left: 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
+    display: block;
     width: 300px;
     height: fit-content;
     margin-inline: 30px;
-    .heading_index {
-      & a {
-        color: $BLUISH-GRAY-500;
-
-        &:hover {
-          color: $BLUISH-GRAY-800;
-          text-decoration: none;
-        }
-      }
-    }
   }
 }

--- a/src/app/_components/HeadingIndexNav/index.tsx
+++ b/src/app/_components/HeadingIndexNav/index.tsx
@@ -1,19 +1,18 @@
 import { extractHeadings } from "@/utils/extractHeadings";
 import React from "react";
 import styles from "./index.module.scss";
+import { TOCList } from "./TOCList";
 
 interface HeadingIndexProps {
   markdown: string;
 }
+
 export const HeadingIndexNav = ({ markdown }: HeadingIndexProps) => {
-  const headingIndexes = extractHeadings(markdown);
+  const headings = extractHeadings(markdown);
+
   return (
-    <nav className={styles.heading_index_nav}>
-      {headingIndexes.map((heading, i) => (
-        <li className={styles.heading_index} key={i}>
-          <a href={`#${heading}`}>{`${heading}`}</a>
-        </li>
-      ))}
+    <nav className={styles.headingIndexNav}>
+      <TOCList headings={headings} />
     </nav>
   );
 };

--- a/src/app/_components/HeadingIndexNav/useTOCHighlight.ts
+++ b/src/app/_components/HeadingIndexNav/useTOCHighlight.ts
@@ -1,0 +1,37 @@
+"use client";
+import { useState, useEffect } from "react";
+import { HeadingType } from "@/types";
+
+export const useTOCHighlight = (headings: HeadingType[]) => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const headingElements = headings
+      .map((heading) => document.getElementById(heading.id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (headingElements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      {
+        rootMargin: "-86px 0px -80% 0px",
+        threshold: 0,
+      }
+    );
+
+    headingElements.forEach((el) => observer.observe(el));
+
+    return () => {
+      headingElements.forEach((el) => observer.unobserve(el));
+    };
+  }, [headings]);
+
+  return activeId;
+};

--- a/src/app/_components/HeadingIndexNav/useTOCHighlight.ts
+++ b/src/app/_components/HeadingIndexNav/useTOCHighlight.ts
@@ -6,7 +6,6 @@ export const useTOCHighlight = (headings: HeadingType[]) => {
   const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
-    console.log(headings);
     const headingElements = headings
       .map((heading) => document.getElementById(heading.id))
       .filter((el): el is HTMLElement => el !== null);

--- a/src/app/_components/HeadingIndexNav/useTOCHighlight.ts
+++ b/src/app/_components/HeadingIndexNav/useTOCHighlight.ts
@@ -6,6 +6,7 @@ export const useTOCHighlight = (headings: HeadingType[]) => {
   const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
+    console.log(headings);
     const headingElements = headings
       .map((heading) => document.getElementById(heading.id))
       .filter((el): el is HTMLElement => el !== null);

--- a/src/app/post/[id]/Markdown/_components/Heading.module.scss
+++ b/src/app/post/[id]/Markdown/_components/Heading.module.scss
@@ -4,19 +4,23 @@
   position: relative;
   width: fit-content;
   cursor: pointer;
-  .link_copy_btn {
+
+  .linkCopyBtn {
     position: absolute;
     right: -35px;
     bottom: 5px;
     padding: 0 10px;
     margin: 0;
+
     @include desktop_screen {
       right: -50px;
       bottom: 10px;
     }
-    &_wrapper {
+
+    &Wrapper {
       width: 20px;
       height: 20px;
+
       @include desktop_screen {
         width: 30px;
         height: 30px;
@@ -25,12 +29,6 @@
   }
 
   .anchor {
-    &:target::before {
-      display: block;
-      height: 86px; /* 헤더의 높이와 동일 */
-      margin-top: -86px; /* 음수 마진으로 헤더 높이만큼 오프셋 조정 */
-      visibility: hidden;
-      content: "";
-    }
+    scroll-margin-top: $HEADER_HEIGHT;
   }
 }

--- a/src/app/post/[id]/Markdown/_components/Heading.module.scss
+++ b/src/app/post/[id]/Markdown/_components/Heading.module.scss
@@ -11,6 +11,9 @@
     bottom: 5px;
     padding: 0 10px;
     margin: 0;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s, visibility 0.2s;
 
     @include desktop_screen {
       right: -50px;
@@ -26,6 +29,11 @@
         height: 30px;
       }
     }
+  }
+
+  &:hover .linkCopyBtn {
+    opacity: 1;
+    visibility: visible;
   }
 
   .anchor {

--- a/src/app/post/[id]/Markdown/_components/Heading.tsx
+++ b/src/app/post/[id]/Markdown/_components/Heading.tsx
@@ -1,15 +1,22 @@
 "use client";
 import React, { PropsWithChildren, useState } from "react";
-import styles from "./Heading3.module.scss";
+import styles from "./Heading.module.scss";
 import Image from "next/image";
 import LinkCopySvg from "@/assets/link_copy.svg";
 import { usePathname } from "next/navigation";
 import { useToast } from "junyeol-components";
 
-export default function Heading3({ children }: PropsWithChildren) {
+interface HeadingProps extends PropsWithChildren {
+  level: 2 | 3 | 4 | 5;
+}
+
+export default function Heading({ children, level }: HeadingProps) {
   const [isHover, setIsHover] = useState(false);
   const pathname = usePathname();
   const toast = useToast();
+
+  const Tag = `h${level}` as const;
+
   return (
     <div
       className={styles.heading}
@@ -18,7 +25,7 @@ export default function Heading3({ children }: PropsWithChildren) {
     >
       {isHover && (
         <button
-          className={styles.link_copy_btn}
+          className={styles.linkCopyBtn}
           onClick={() => {
             navigator.clipboard
               .writeText(window.location.host + pathname + "#" + children)
@@ -30,14 +37,14 @@ export default function Heading3({ children }: PropsWithChildren) {
               });
           }}
         >
-          <div className={styles.link_copy_btn_wrapper}>
+          <div className={styles.linkCopyBtnWrapper}>
             <Image src={LinkCopySvg} width={30} height={30} alt="링크복사svg" />
           </div>
         </button>
       )}
-      <h3 className={styles.anchor} id={children as string}>
+      <Tag className={styles.anchor} id={children as string}>
         {children}
-      </h3>
+      </Tag>
     </div>
   );
 }

--- a/src/app/post/[id]/Markdown/_components/Heading.tsx
+++ b/src/app/post/[id]/Markdown/_components/Heading.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { PropsWithChildren, useState } from "react";
+import React, { PropsWithChildren } from "react";
 import styles from "./Heading.module.scss";
 import Image from "next/image";
 import LinkCopySvg from "@/assets/link_copy.svg";
@@ -11,37 +11,42 @@ interface HeadingProps extends PropsWithChildren {
 }
 
 export default function Heading({ children, level }: HeadingProps) {
-  const [isHover, setIsHover] = useState(false);
   const pathname = usePathname();
   const toast = useToast();
 
   const Tag = `h${level}` as const;
 
   return (
-    <div
-      className={styles.heading}
-      onMouseOver={() => setIsHover(true)}
-      onMouseOut={() => setIsHover(false)}
-    >
-      {isHover && (
-        <button
-          className={styles.linkCopyBtn}
-          onClick={() => {
-            navigator.clipboard
-              .writeText(window.location.host + pathname + "#" + children)
-              .then(() => {
-                toast({
-                  children: "링크가 복사되었습니다.",
-                  type: "success",
-                });
+    <div className={styles.heading}>
+      <button
+        className={styles.linkCopyBtn}
+        onClick={() => {
+          navigator.clipboard
+            .writeText(window.location.host + pathname + "#" + children)
+            .then(() => {
+              toast({
+                children: "링크가 복사되었습니다.",
+                type: "success",
               });
-          }}
-        >
-          <div className={styles.linkCopyBtnWrapper}>
-            <Image src={LinkCopySvg} width={30} height={30} alt="링크복사svg" />
-          </div>
-        </button>
-      )}
+            })
+            .catch(() => {
+              toast({
+                children: (
+                  <>
+                    링크 복사에 실패했습니다.
+                    <br />
+                    홈페이지 하단의 연락처로 제보주세요
+                  </>
+                ),
+                type: "fail",
+              });
+            });
+        }}
+      >
+        <div className={styles.linkCopyBtnWrapper}>
+          <Image src={LinkCopySvg} width={30} height={30} alt="링크복사svg" />
+        </div>
+      </button>
       <Tag className={styles.anchor} id={children as string}>
         {children}
       </Tag>

--- a/src/app/post/[id]/Markdown/index.tsx
+++ b/src/app/post/[id]/Markdown/index.tsx
@@ -8,7 +8,7 @@ import remarkGfm from "remark-gfm";
 import { MarkdownImage } from "@/app/_components/MarkdownImage";
 import styles from "./index.module.scss";
 import { Suspense, lazy } from "react";
-import Heading3 from "@/app/post/[id]/Markdown/_components/Heading3";
+import Heading from "@/app/post/[id]/Markdown/_components/Heading";
 import CommentScript from "@/app/post/[id]/Markdown/_components/CommnetScript";
 
 const Code = lazy(() => import("@/app/post/[id]/Markdown/_components/Code"));
@@ -27,7 +27,10 @@ export default function Markdown({ markdown }: PostProps) {
               {children}
             </a>
           ),
-          h3: ({ children }) => <Heading3>{children}</Heading3>,
+          h2: ({ children }) => <Heading level={2}>{children}</Heading>,
+          h3: ({ children }) => <Heading level={3}>{children}</Heading>,
+          h4: ({ children }) => <Heading level={4}>{children}</Heading>,
+          h5: ({ children }) => <Heading level={5}>{children}</Heading>,
           code({ className, children, ...props }) {
             const match = /language-(\w+)/.exec(className || "");
             if (match === null) {

--- a/src/styles/libs/_vars.scss
+++ b/src/styles/libs/_vars.scss
@@ -14,6 +14,9 @@ $SMALL: 0.875rem; // 14px
 $SMALL2X: 0.75rem; // 12px
 $SMALL3X: 0.6875rem; // 11px
 
+// * Header
+$HEADER_HEIGHT: 86px;
+
 // * Sidebar
 $SIDEBAR_OPENED: 347px;
 $SIDEBAR_CLOSED: 60px;

--- a/src/types/headingType.ts
+++ b/src/types/headingType.ts
@@ -1,0 +1,5 @@
+export interface HeadingType {
+  text: string; // 헤딩 텍스트
+  level: number; // 2, 3, 4, 5
+  id: string; // 스크롤 타겟 ID
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,7 @@
 import "./nextSegmentType";
 import "./apiResponseType";
+import "./headingType";
 
 export * from "./apiResponseType";
 export * from "./nextSegmentType";
+export * from "./headingType";

--- a/src/utils/extractHeadings.ts
+++ b/src/utils/extractHeadings.ts
@@ -3,7 +3,7 @@ import { HeadingType } from "@/types";
 export const extractHeadings = (markdown: string): HeadingType[] => {
   const regex = /^(#{2,5})\s+(.*)$/gm;
 
-  return [...markdown.matchAll(regex)].map(([, hashes, title]) => ({
+  return Array.from(markdown.matchAll(regex), ([, hashes, title]) => ({
     text: title,
     level: hashes.length,
     id: title,

--- a/src/utils/extractHeadings.ts
+++ b/src/utils/extractHeadings.ts
@@ -2,17 +2,10 @@ import { HeadingType } from "@/types";
 
 export const extractHeadings = (markdown: string): HeadingType[] => {
   const regex = /^(#{2,5})\s+(.*)$/gm;
-  const headings: HeadingType[] = [];
 
-  let match;
-  while ((match = regex.exec(markdown)) !== null) {
-    const [, hashes, title] = match;
-    headings.push({
-      text: title,
-      level: hashes.length,
-      id: title,
-    });
-  }
-
-  return headings;
+  return [...markdown.matchAll(regex)].map(([, hashes, title]) => ({
+    text: title,
+    level: hashes.length,
+    id: title,
+  }));
 };

--- a/src/utils/extractHeadings.ts
+++ b/src/utils/extractHeadings.ts
@@ -1,15 +1,18 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-export const extractHeadings = (markdown: string): string[] => {
-  const regex = /^(###)\s+(.*)$/gm;
-  const matches = markdown.matchAll(regex);
-  const headings: string[] = [];
-  //   @ts-expect-error
-  for (const match of matches) {
+import { HeadingType } from "@/types";
+
+export const extractHeadings = (markdown: string): HeadingType[] => {
+  const regex = /^(#{2,5})\s+(.*)$/gm;
+  const headings: HeadingType[] = [];
+
+  let match;
+  while ((match = regex.exec(markdown)) !== null) {
     const [, hashes, title] = match;
-    const level = hashes.length - 1;
-    headings.push(`${"#".repeat(level)} ${title}`);
+    headings.push({
+      text: title,
+      level: hashes.length,
+      id: title,
+    });
   }
 
-  const cleanIndexes = headings.map((heading) => heading.replace(/^#+\s*/, ""));
-  return cleanIndexes;
+  return headings;
 };


### PR DESCRIPTION
## Summary
- H2~H5 헤딩 추출 및 계층적 들여쓰기 표시
- Intersection Observer 기반 현재 섹션 파란색 하이라이트
- 통합 Heading 컴포넌트로 h2~h5 렌더링 통합
- 86px 고정 헤더 오프셋 처리 (scroll-margin-top, rootMargin)
- HeadingType 타입 정의로 타입 안정성 강화
- CLAUDE.md에 TOC 아키텍처 문서화
- Link vs a 태그 컨벤션 규칙 추가

## Test plan
- [x] 포스트 페이지에서 H2~H5 헤딩이 TOC에 모두 표시되는지 확인
- [x] 스크롤 시 현재 섹션이 파란색으로 하이라이트되는지 확인
- [x] TOC 항목 클릭 시 해당 위치로 부드럽게 이동하는지 확인
- [x] 이동 후 헤딩이 고정헤더에 가려지지 않는지 확인 (86px offset)
- [x] 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.ai/code)